### PR TITLE
Fix pixel alignment kept at default when loading textures from STBI

### DIFF
--- a/TerraForge3D/src/Base/Texture2D.cpp
+++ b/TerraForge3D/src/Base/Texture2D.cpp
@@ -49,7 +49,7 @@ Texture2D::Texture2D(const std::string path, bool preserveData, bool readAlpha)
 
 		glGenTextures(1, &m_RendererID);
 		glBindTexture(GL_TEXTURE_2D, m_RendererID);
-
+		glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
 		if(readAlpha)
 			glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB8, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, data);
 		else


### PR DESCRIPTION
Not sure if this breaks any of the SetData calls, should be audited.