### PR TITLE
Fix uniform IDs not being initialized

### DIFF
--- a/TerraForge3D/src/Base/Shader.h
+++ b/TerraForge3D/src/Base/Shader.h
@@ -27,7 +27,7 @@ public:
 
 	inline int GetNativeShader() { return m_Shader; }
 
-	int m_Shader, m_UniformId, m_LightPosUniformID, m_LightColUniformID, m_TimeUniformID;
+	int m_Shader=0, m_UniformId=0, m_LightPosUniformID=0, m_LightColUniformID=0, m_TimeUniformID=0;
 	std::unordered_map<std::string, uint32_t> uniformLocations;
 
 };


### PR DESCRIPTION
Prevented the _PV matrix from being loaded into the geometry shader, hence not showing anything.