### PR TITLE
Linux fix paths

### DIFF
--- a/TerraForge3D/include/Platform.h
+++ b/TerraForge3D/include/Platform.h
@@ -2,10 +2,10 @@
 
 #ifdef TERR3D_WIN32
 
-#define PATH_SEPERATOR "\\"
+#define PATH_SEPARATOR "\\"
 
 #else
 
-#define PATH_SEPERATOR "/"
+#define PATH_SEPARATOR "/"
 
 #endif

--- a/TerraForge3D/src/Base/Logging/Logger.cpp
+++ b/TerraForge3D/src/Base/Logging/Logger.cpp
@@ -14,7 +14,7 @@ Logger::Logger(std::string logsDir)
 	strftime(buffer, sizeof(buffer), "%A %d-%m-%Y %I-%M-%S %p", timeinfo);
 	std::string str(buffer);
 	str += ".txt";
-	mLogHandler = new LoggingOutputStreambuf(std::cout, logsDir + PATH_SEPERATOR + str);
+	mLogHandler = new LoggingOutputStreambuf(std::cout, logsDir + PATH_SEPARATOR + str);
 }
 
 Logger::~Logger()

--- a/TerraForge3D/src/Data/ProjectData.cpp
+++ b/TerraForge3D/src/Data/ProjectData.cpp
@@ -1,10 +1,10 @@
 #include "Data/ProjectData.h"
 #include "Data/ApplicationState.h"
 #include "Utils/Utils.h"
+#include "Platform.h"
 
 #include <json/json.hpp>
 
-#include "Platform.h"
 
 ProjectManager *ProjectManager::s_ProjectManager;
 
@@ -81,12 +81,12 @@ void ProjectManager::SaveDatabase()
 		MkDir(GetResourcePath());
 	}
 
-	SaveToFile(GetResourcePath() + PATH_SEPERATOR "project_database.terr3d", projectDatase.dump());
+	SaveToFile(GetResourcePath() + PATH_SEPARATOR "project_database.terr3d", projectDatase.dump());
 }
 
 std::string ProjectManager::GetResourcePath()
 {
-	return GetExecutableDir() + PATH_SEPERATOR "Data" PATH_SEPERATOR "cache" PATH_SEPERATOR "project_data" PATH_SEPERATOR "project_" + GetId();
+	return GetExecutableDir() + PATH_SEPARATOR "Data" PATH_SEPARATOR "cache" PATH_SEPARATOR "project_data" PATH_SEPARATOR "project_" + GetId();
 }
 
 std::string ProjectManager::SaveTexture(Texture2D *texture)
@@ -102,9 +102,9 @@ std::string ProjectManager::SaveTexture(Texture2D *texture)
 
 	if (GetAsset(hash).size() <= 0)
 	{
-		MkDir(GetResourcePath() + PATH_SEPERATOR "textures");
-		CopyFileData(path, GetResourcePath() + PATH_SEPERATOR "textures" PATH_SEPERATOR + hash);
-		RegisterAsset(hash, "textures" PATH_SEPERATOR + hash);
+		MkDir(GetResourcePath() + PATH_SEPARATOR "textures");
+		CopyFileData(path, GetResourcePath() + PATH_SEPARATOR "textures" PATH_SEPARATOR + hash);
+		RegisterAsset(hash, "textures" PATH_SEPARATOR + hash);
 	}
 
 	return hash;

--- a/TerraForge3D/src/Data/Serializer.cpp
+++ b/TerraForge3D/src/Data/Serializer.cpp
@@ -6,6 +6,7 @@
 #include "Data/ApplicationState.h"
 #include "Misc/AppStyles.h"
 #include "Shading/ShadingManager.h"
+#include "Platform.h"
 
 #ifdef TERR3D_WIN32
 #include "dirent/dirent.h"
@@ -46,7 +47,7 @@ static void zip_walk(struct zip_t *zip, const char *path, bool isFristLayer = tr
 
 		if (S_ISDIR(s.st_mode))
 		{
-			zip_walk(zip, fullpath, false, prevPath + entry->d_name + "\\");
+			zip_walk(zip, fullpath, false, prevPath + entry->d_name + PATH_SEPARATOR);
 		}
 
 		else
@@ -116,9 +117,9 @@ nlohmann::json Serializer::Serialize()
 
 		if (projectAsset == "")
 		{
-			MkDir(appState->projectManager->GetResourcePath() + "\\models");
-			CopyFileData(appState->globals.currentBaseModelPath, appState->projectManager->GetResourcePath() + "\\models\\" + baseHash + appState->globals.currentBaseModelPath.substr(appState->globals.currentBaseModelPath.find_last_of(".")));
-			appState->projectManager->RegisterAsset(baseHash, "models\\" + baseHash + appState->globals.currentBaseModelPath.substr(appState->globals.currentBaseModelPath.find_last_of(".")));
+			MkDir(appState->projectManager->GetResourcePath() + PATH_SEPARATOR "models");
+			CopyFileData(appState->globals.currentBaseModelPath, appState->projectManager->GetResourcePath() + PATH_SEPARATOR "models" + PATH_SEPARATOR + baseHash + appState->globals.currentBaseModelPath.substr(appState->globals.currentBaseModelPath.find_last_of(".")));
+			appState->projectManager->RegisterAsset(baseHash, "models" + PATH_SEPARATOR + baseHash + appState->globals.currentBaseModelPath.substr(appState->globals.currentBaseModelPath.find_last_of(".")));
 		}
 
 		data["baseid"] = baseHash;
@@ -137,12 +138,12 @@ void Serializer::PackProject(std::string path)
 
 	Serialize();
 	std::ofstream outfile;
-	outfile.open(appState->projectManager->GetResourcePath() + "\\project.terr3d");
+	outfile.open(appState->projectManager->GetResourcePath() + PATH_SEPARATOR "project.terr3d");
 	outfile << data.dump(4, ' ', false);
 	outfile.close();
-	MkDir(GetExecutableDir() + "\\Data\\temp");
+	MkDir(GetExecutableDir() + PATH_SEPARATOR "Data" PATH_SEPARATOR "temp");
 	std::string uid = GenerateId(64);
-	SaveFile(GetExecutableDir() + "\\Data\\temp\\" + uid);
+	SaveFile(GetExecutableDir() + "Data" + PATH_SEPARATOR "temp" + PATH_SEPARATOR + uid);
 	zip_t *packed = zip_open(path.c_str(), 9, 'w');
 	zip_walk(packed, appState->projectManager->GetResourcePath().c_str());
 	zip_close(packed);
@@ -156,16 +157,24 @@ void Serializer::LoadPackedProject(std::string path)
 	}
 
 	std::string uid = GenerateId(64);
-	MkDir(GetExecutableDir() + "\\Data\\temp\\pcache_" + uid);
-	zip_extract(path.c_str(), (GetExecutableDir() + "\\Data\\temp\\pcache_" + uid).c_str(), [](const char *filename, void *arg)
+	MkDir(GetExecutableDir() + PATH_SEPARATOR "Data" + PATH_SEPARATOR +
+			"temp" PATH_SEPARATOR "pcache_" + uid);
+	zip_extract(path.c_str(), (GetExecutableDir() + PATH_SEPARATOR "Data" +
+				PATH_SEPARATOR "temp" PATH_SEPARATOR "pcache_" +
+				uid).c_str(), [](const char *filename, void *arg)
 	{
 		return 1;
 	}, (void *)0);
 
-	if (FileExists(GetExecutableDir() + "\\Data\\temp\\pcache_" + uid + "\\project.terr3d", true))
+	if (FileExists(GetExecutableDir() + PATH_SEPARATOR "Data" +
+				PATH_SEPARATOR "temp" PATH_SEPARATOR "pcache_" + uid +
+				PATH_SEPARATOR "project.terr3d", true))
 	{
 		bool tmp = false;
-		std::string sdata = ReadShaderSourceFile(GetExecutableDir() + "\\Data\\temp\\pcache_" + uid + "\\project.terr3d", &tmp);
+		std::string sdata = ReadShaderSourceFile(GetExecutableDir() +
+				PATH_SEPARATOR "Data" PATH_SEPARATOR "temp" +
+				PATH_SEPARATOR "pcache_" + uid + PATH_SEPARATOR +
+				"project.terr3d", &tmp);
 
 		if (sdata.size() <= 0)
 		{
@@ -187,15 +196,22 @@ void Serializer::LoadPackedProject(std::string path)
 		}
 
 		std::string projId = data["projectID"];
-		zip_extract(path.c_str(), (GetExecutableDir() + "\\Data\\cache\\project_data\\project_" + projId).c_str(), [](const char *filename, void *arg)
+		zip_extract(path.c_str(), (GetExecutableDir() + PATH_SEPARATOR "Data"
+					+ PATH_SEPARATOR "cache" + PATH_SEPARATOR +
+					"project_data" PATH_SEPARATOR "project_" +
+					projId).c_str(), [](const char *filename, void *arg)
 		{
 			Log(std::string("Extracted ") + filename);
 			return 1;
 		}, (void *)0);
-		std::string oriDir = path.substr(0, path.rfind("\\"));
-		std::string oriName = path.substr(path.rfind("\\") + 1);
-		CopyFileData((GetExecutableDir() + "\\Data\\cache\\project_data\\project_" + projId + "\\project.terr3d").c_str(), oriDir + "\\" + oriName + ".terr3d");
-		LoadFile(oriDir + "\\" + oriName + ".terr3d");
+		std::string oriDir = path.substr(0, path.rfind(PATH_SEPARATOR));
+		std::string oriName = path.substr(path.rfind(PATH_SEPARATOR) + 1);
+		CopyFileData((GetExecutableDir() + PATH_SEPARATOR "Data" +
+					PATH_SEPARATOR "cache" + PATH_SEPARATOR + +
+					"project_data" PATH_SEPARATOR "project_" + projId +
+					PATH_SEPARATOR "project.terr3d").c_str(), oriDir +
+				PATH_SEPARATOR + oriName + ".terr3d");
+		LoadFile(oriDir + PATH_SEPARATOR + oriName + ".terr3d");
 	}
 
 	else
@@ -223,7 +239,7 @@ void Serializer::SaveFile(std::string path)
 
 	Serialize();
 	std::ofstream outfile;
-	outfile.open(appState->projectManager->GetResourcePath() + "\\project.terr3d");
+	outfile.open(appState->projectManager->GetResourcePath() + PATH_SEPARATOR "project.terr3d");
 	outfile << data.dump(4, ' ', false);
 	outfile.close();
 	outfile.open(path);
@@ -356,7 +372,7 @@ ApplicationState *Serializer::Deserialize(nlohmann::json d)
 				delete appState->models.customBaseCopy;
 			}
 
-			appState->globals.currentBaseModelPath = appState->projectManager->GetResourcePath() + "\\" + projectAsset;
+			appState->globals.currentBaseModelPath = appState->projectManager->GetResourcePath() + PATH_SEPARATOR + projectAsset;
 			appState->models.customBase = LoadModel(appState->globals.currentBaseModelPath);
 			appState->models.customBaseCopy = LoadModel(appState->globals.currentBaseModelPath);
 			appState->states.usingBase = false;

--- a/TerraForge3D/src/Data/Serializer.cpp
+++ b/TerraForge3D/src/Data/Serializer.cpp
@@ -118,8 +118,8 @@ nlohmann::json Serializer::Serialize()
 		if (projectAsset == "")
 		{
 			MkDir(appState->projectManager->GetResourcePath() + PATH_SEPARATOR "models");
-			CopyFileData(appState->globals.currentBaseModelPath, appState->projectManager->GetResourcePath() + PATH_SEPARATOR "models" + PATH_SEPARATOR + baseHash + appState->globals.currentBaseModelPath.substr(appState->globals.currentBaseModelPath.find_last_of(".")));
-			appState->projectManager->RegisterAsset(baseHash, "models" + PATH_SEPARATOR + baseHash + appState->globals.currentBaseModelPath.substr(appState->globals.currentBaseModelPath.find_last_of(".")));
+			CopyFileData(appState->globals.currentBaseModelPath, appState->projectManager->GetResourcePath() + PATH_SEPARATOR "models" PATH_SEPARATOR + baseHash + appState->globals.currentBaseModelPath.substr(appState->globals.currentBaseModelPath.find_last_of(".")));
+			appState->projectManager->RegisterAsset(baseHash, "models" PATH_SEPARATOR + baseHash + appState->globals.currentBaseModelPath.substr(appState->globals.currentBaseModelPath.find_last_of(".")));
 		}
 
 		data["baseid"] = baseHash;
@@ -143,7 +143,7 @@ void Serializer::PackProject(std::string path)
 	outfile.close();
 	MkDir(GetExecutableDir() + PATH_SEPARATOR "Data" PATH_SEPARATOR "temp");
 	std::string uid = GenerateId(64);
-	SaveFile(GetExecutableDir() + "Data" + PATH_SEPARATOR "temp" + PATH_SEPARATOR + uid);
+	SaveFile(GetExecutableDir() + "Data" + PATH_SEPARATOR "temp" PATH_SEPARATOR + uid);
 	zip_t *packed = zip_open(path.c_str(), 9, 'w');
 	zip_walk(packed, appState->projectManager->GetResourcePath().c_str());
 	zip_close(packed);
@@ -157,24 +157,21 @@ void Serializer::LoadPackedProject(std::string path)
 	}
 
 	std::string uid = GenerateId(64);
-	MkDir(GetExecutableDir() + PATH_SEPARATOR "Data" + PATH_SEPARATOR +
-			"temp" PATH_SEPARATOR "pcache_" + uid);
-	zip_extract(path.c_str(), (GetExecutableDir() + PATH_SEPARATOR "Data" +
-				PATH_SEPARATOR "temp" PATH_SEPARATOR "pcache_" +
-				uid).c_str(), [](const char *filename, void *arg)
+	MkDir(GetExecutableDir() + PATH_SEPARATOR "Data" PATH_SEPARATOR "temp"
+			PATH_SEPARATOR "pcache_" + uid);
+	zip_extract(path.c_str(), (GetExecutableDir() + PATH_SEPARATOR "Data"
+				PATH_SEPARATOR "temp" PATH_SEPARATOR "pcache_" + uid).c_str(),
+			[](const char *filename, void *arg)
 	{
 		return 1;
 	}, (void *)0);
 
-	if (FileExists(GetExecutableDir() + PATH_SEPARATOR "Data" +
-				PATH_SEPARATOR "temp" PATH_SEPARATOR "pcache_" + uid +
-				PATH_SEPARATOR "project.terr3d", true))
+	if (FileExists(GetExecutableDir() + PATH_SEPARATOR "Data" PATH_SEPARATOR "temp" PATH_SEPARATOR "pcache_" + uid + PATH_SEPARATOR "project.terr3d", true))
 	{
 		bool tmp = false;
 		std::string sdata = ReadShaderSourceFile(GetExecutableDir() +
-				PATH_SEPARATOR "Data" PATH_SEPARATOR "temp" +
-				PATH_SEPARATOR "pcache_" + uid + PATH_SEPARATOR +
-				"project.terr3d", &tmp);
+				PATH_SEPARATOR "Data" PATH_SEPARATOR "temp" PATH_SEPARATOR
+				"pcache_" + uid + PATH_SEPARATOR "project.terr3d", &tmp);
 
 		if (sdata.size() <= 0)
 		{
@@ -197,20 +194,20 @@ void Serializer::LoadPackedProject(std::string path)
 
 		std::string projId = data["projectID"];
 		zip_extract(path.c_str(), (GetExecutableDir() + PATH_SEPARATOR "Data"
-					+ PATH_SEPARATOR "cache" + PATH_SEPARATOR +
-					"project_data" PATH_SEPARATOR "project_" +
-					projId).c_str(), [](const char *filename, void *arg)
+					PATH_SEPARATOR "cache" PATH_SEPARATOR "project_data"
+					PATH_SEPARATOR "project_" + projId).c_str(), [](const char
+						*filename, void *arg)
 		{
 			Log(std::string("Extracted ") + filename);
 			return 1;
 		}, (void *)0);
 		std::string oriDir = path.substr(0, path.rfind(PATH_SEPARATOR));
 		std::string oriName = path.substr(path.rfind(PATH_SEPARATOR) + 1);
-		CopyFileData((GetExecutableDir() + PATH_SEPARATOR "Data" +
-					PATH_SEPARATOR "cache" + PATH_SEPARATOR + +
-					"project_data" PATH_SEPARATOR "project_" + projId +
-					PATH_SEPARATOR "project.terr3d").c_str(), oriDir +
-				PATH_SEPARATOR + oriName + ".terr3d");
+		CopyFileData((GetExecutableDir() + PATH_SEPARATOR "Data" PATH_SEPARATOR
+					"cache" PATH_SEPARATOR "project_data" PATH_SEPARATOR
+					"project_" + projId + PATH_SEPARATOR
+					"project.terr3d").c_str(), oriDir + PATH_SEPARATOR +
+				oriName + ".terr3d");
 		LoadFile(oriDir + PATH_SEPARATOR + oriName + ".terr3d");
 	}
 

--- a/TerraForge3D/src/Filters/AdvancedErosionFilter.cpp
+++ b/TerraForge3D/src/Filters/AdvancedErosionFilter.cpp
@@ -4,6 +4,7 @@
 #include "Data/ApplicationState.h"
 
 #include "Utils/Utils.h"
+#include "Platform.h"
 
 #include <imgui.h>
 #include <iostream>
@@ -72,12 +73,15 @@ void AdvancedErosionFilter::Apply()
 			localWorkSize = 1;
 		}
 
-		std::string kernelSrc = ReadShaderSourceFile(GetExecutableDir() + "\\Data\\kernels\\advanced_erosion.cl", &tmp);
+		std::string kernelSrc = ReadShaderSourceFile(GetExecutableDir() +
+				PATH_SEPARATOR "Data" PATH_SEPARATOR "kernels" +
+				PATH_SEPARATOR "advanced_erosion.cl", &tmp);
 		// Some constants
 		kernelSrc = std::regex_replace(kernelSrc, std::regex("LOCAL_WORK_SIZE"), std::to_string(localWorkSize));
 		kernels.Clear();
 		kernels.AddSoruce(kernelSrc);
-		kernels.BuildProgram("-I\"" + GetExecutableDir() + "\\Data\\kernels" + "\"");
+		kernels.BuildProgram("-I\"" + GetExecutableDir() + PATH_SEPARATOR +
+				"Data" PATH_SEPARATOR "kernels" + "\"");
 		kernels.AddKernel("erode");
 		kernels.CreateBuffer("mesh", CL_MEM_READ_WRITE, sizeof(Vert) * model->mesh->vertexCount);
 		kernels.WriteBuffer("mesh", true, sizeof(Vert) * model->mesh->vertexCount, model->mesh->vert);

--- a/TerraForge3D/src/Filters/AdvancedErosionFilter.cpp
+++ b/TerraForge3D/src/Filters/AdvancedErosionFilter.cpp
@@ -74,13 +74,13 @@ void AdvancedErosionFilter::Apply()
 		}
 
 		std::string kernelSrc = ReadShaderSourceFile(GetExecutableDir() +
-				PATH_SEPARATOR "Data" PATH_SEPARATOR "kernels" +
+				PATH_SEPARATOR "Data" PATH_SEPARATOR "kernels"
 				PATH_SEPARATOR "advanced_erosion.cl", &tmp);
 		// Some constants
 		kernelSrc = std::regex_replace(kernelSrc, std::regex("LOCAL_WORK_SIZE"), std::to_string(localWorkSize));
 		kernels.Clear();
 		kernels.AddSoruce(kernelSrc);
-		kernels.BuildProgram("-I\"" + GetExecutableDir() + PATH_SEPARATOR +
+		kernels.BuildProgram("-I\"" + GetExecutableDir() + PATH_SEPARATOR
 				"Data" PATH_SEPARATOR "kernels" + "\"");
 		kernels.AddKernel("erode");
 		kernels.CreateBuffer("mesh", CL_MEM_READ_WRITE, sizeof(Vert) * model->mesh->vertexCount);

--- a/TerraForge3D/src/Filters/GPUErosionFilter.cpp
+++ b/TerraForge3D/src/Filters/GPUErosionFilter.cpp
@@ -3,6 +3,7 @@
 #include <iostream>
 
 #include "Data/ApplicationState.h"
+#include "Platform.h"
 
 #include <ComputeShader.h>
 #include <ShaderStorageBuffer.h>
@@ -80,7 +81,7 @@ void GPUErosionFilter::Apply()
 	mapSize = model->mesh->res;
 	mapSize = MAX(0, mapSize - 2 * erosionBrushRadius);
 	bool tmp = false;
-	std::string shaderSrc = ReadShaderSourceFile(GetExecutableDir() + "\\Data\\compute\\erosion.glsl", &tmp);
+	std::string shaderSrc = ReadShaderSourceFile(GetExecutableDir() + PATH_SEPARATOR "Data" PATH_SEPARATOR "compute" PATH_SEPARATOR "erosion.glsl", &tmp);
 	shaderSrc = std::regex_replace(shaderSrc, std::regex("LAYOUT_SIZE_X"), std::to_string(1024));
 	//shaderSrc = std::regex_replace(shaderSrc, std::regex("LAYOUT_SIZE_X"), std::to_string(1));
 	shaderSrc = std::regex_replace(shaderSrc, std::regex("LAYOUT_SIZE_Y"), std::to_string(1));

--- a/TerraForge3D/src/Foliage/FoliagePlacement.cpp
+++ b/TerraForge3D/src/Foliage/FoliagePlacement.cpp
@@ -5,6 +5,7 @@
 #include "Base/Texture2D.h"
 #include "Data/ProjectData.h"
 #include "Data/ApplicationState.h"
+#include "Platform.h"
 
 #include <glm/gtc/type_ptr.hpp>
 #include <imgui/imgui.h>
@@ -139,8 +140,8 @@ void FoliageManager::ShowSettings(bool *pOpen)
 
 		if(path.size() > 3)
 		{
-			foliageItems.push_back(new FoliageItem(appState->constants.texturesDir + "\\white.png"));
-			foliageItems.back()->name = path.substr(path.find("\\") + 1);
+			foliageItems.push_back(new FoliageItem(appState->constants.texturesDir + PATH_SEPARATOR "white.png"));
+			foliageItems.back()->name = path.substr(path.find(PATH_SEPARATOR) + 1);
 			foliageItems.back()->model = LoadModel(path);
 			foliageItems.back()->model->SetupMeshOnGPU();
 			foliageItems.back()->model->UploadToGPU();
@@ -156,9 +157,9 @@ void FoliageManager::ShowSettings(bool *pOpen)
 	{
 		delete appState->shaders.foliage;
 		bool res = false;
-		appState->shaders.foliage = new Shader(ReadShaderSourceFile(appState->constants.shadersDir + "\\foliage\\vert.glsl", &res),
-		                                       ReadShaderSourceFile(appState->constants.shadersDir + "\\foliage\\frag.glsl", &res),
-		                                       ReadShaderSourceFile(appState->constants.shadersDir + "\\foliage\\geom.glsl", &res));
+		appState->shaders.foliage = new Shader(ReadShaderSourceFile(appState->constants.shadersDir + PATH_SEPARATOR "foliage" PATH_SEPARATOR "vert.glsl", &res),
+		                                       ReadShaderSourceFile(appState->constants.shadersDir + PATH_SEPARATOR "foliage" PATH_SEPARATOR "frag.glsl", &res),
+		                                       ReadShaderSourceFile(appState->constants.shadersDir + PATH_SEPARATOR "foliage" PATH_SEPARATOR "geom.glsl", &res));
 	}
 
 	ImGui::End();

--- a/TerraForge3D/src/Generators/CPUNodeEditor/CPUNodeEditor.cpp
+++ b/TerraForge3D/src/Generators/CPUNodeEditor/CPUNodeEditor.cpp
@@ -3,6 +3,7 @@
 #include "Data/ApplicationState.h"
 #include "Profiler.h"
 #include "Utils/Utils.h"
+#include "Platform.h"
 
 #include "imgui.h"
 #include "Base/ImGuiShapes.h"
@@ -134,7 +135,7 @@ CPUNodeEditor::CPUNodeEditor(ApplicationState *as)
 	name.reserve(1024);
 	name = "CPU Node Editor " + std::to_string(count++);
 	NodeEditorConfig config;
-	config.saveFile = GetExecutableDir() + "\\Data\\configs\\CPUNodeEditorconfigs.terr3d";
+	config.saveFile = GetExecutableDir() + PATH_SEPARATOR "Data" PATH_SEPARATOR "configs" PATH_SEPARATOR "CPUNodeEditorconfigs.terr3d";
 	config.makeNodeFunc = [&]()
 	{
 		ImGuiNodeEditor::Suspend();

--- a/TerraForge3D/src/Generators/CPUNodeEditor/Nodes/TextureNode.cpp
+++ b/TerraForge3D/src/Generators/CPUNodeEditor/Nodes/TextureNode.cpp
@@ -9,6 +9,7 @@
 #include <mutex>
 #include <cmath>
 #include "Base/ImGuiCurveEditor.h"
+#include "Platform.h"
 
 #define CLAMP01(x) x > 1 ? 1 : ( x < 0 ? 0 : x )
 
@@ -130,7 +131,7 @@ void TextureNode::Load(nlohmann::json data)
 	if (isDefault)
 	{
 		delete texture;
-		texture = new Texture2D(GetExecutableDir() + "\\Data\\textures\\white.png", false, false);
+		texture = new Texture2D(GetExecutableDir() + PATH_SEPARATOR "Data" PATH_SEPARATOR "textures" PATH_SEPARATOR "white.png", false, false);
 	}
 
 	else
@@ -146,7 +147,7 @@ void TextureNode::Load(nlohmann::json data)
 		else
 		{
 			delete texture;
-			texture = new Texture2D(ProjectManager::Get()->GetResourcePath() + "\\" + ProjectManager::Get()->GetAsset(hash));
+			texture = new Texture2D(ProjectManager::Get()->GetResourcePath() + PATH_SEPARATOR + ProjectManager::Get()->GetAsset(hash));
 			Log("Loaded Cached Texture : " + hash);
 		}
 	}
@@ -285,7 +286,7 @@ TextureNode::TextureNode()
 	outputPins.push_back(new NodeEditorPin(NodeEditorPinType::Output));
 	outputPins.push_back(new NodeEditorPin(NodeEditorPinType::Output));
 	headerColor = ImColor(IMAGE_NODE_COLOR);
-	texture = new Texture2D(GetExecutableDir() + "\\Data\\textures\\white.png", false, false);
+	texture = new Texture2D(GetExecutableDir() + PATH_SEPARATOR "Data" PATH_SEPARATOR "textures" PATH_SEPARATOR "white.png", false, false);
 	isDefault = true;
 	scale = 1.0f;
 	inv = false;

--- a/TerraForge3D/src/Generators/MeshGeneratorManager.cpp
+++ b/TerraForge3D/src/Generators/MeshGeneratorManager.cpp
@@ -12,6 +12,7 @@
 #include "Base/UIFontManager.h"
 
 #include "Profiler.h"
+#include "Platform.h"
 
 MeshGeneratorManager::MeshGeneratorManager(ApplicationState *as)
 	:appState(as)
@@ -436,7 +437,7 @@ void MeshGeneratorManager::ExecuteCPUGenerators()
 void MeshGeneratorManager::LoadKernels()
 {
 	bool tmp = false;
-	std::string source = ReadShaderSourceFile(GetExecutableDir() + "\\Data\\kernels\\generators\\generators.cl", &tmp);
+	std::string source = ReadShaderSourceFile(GetExecutableDir() + PATH_SEPARATOR "Data" PATH_SEPARATOR "kernels" PATH_SEPARATOR "generators" PATH_SEPARATOR "generators.cl", &tmp);
 	kernels->AddSoruce(source);
 	kernels->BuildProgram("-I" + appState->globals.kernelsIncludeDir + " -cl-fast-relaxed-math -cl-mad-enable");
 	kernels->AddKernel("clear_mesh_terrain");

--- a/TerraForge3D/src/Main.cpp
+++ b/TerraForge3D/src/Main.cpp
@@ -102,22 +102,22 @@ static void ResetShader()
 
 	if (!appState->shaders.wireframe)
 	{
-		appState->shaders.wireframe = new Shader(ReadShaderSourceFile(appState->constants.shadersDir + PATH_SEPERATOR "default" PATH_SEPERATOR "vert.glsl", &res),
-		        ReadShaderSourceFile(appState->constants.shadersDir + PATH_SEPERATOR "default" PATH_SEPERATOR "frag.glsl", &res),
-		        ReadShaderSourceFile(appState->constants.shadersDir + PATH_SEPERATOR "default" PATH_SEPERATOR "geom.glsl", &res));
+		appState->shaders.wireframe = new Shader(ReadShaderSourceFile(appState->constants.shadersDir + PATH_SEPARATOR "default" PATH_SEPARATOR "vert.glsl", &res),
+		        ReadShaderSourceFile(appState->constants.shadersDir + PATH_SEPARATOR "default" PATH_SEPARATOR "frag.glsl", &res),
+		        ReadShaderSourceFile(appState->constants.shadersDir + PATH_SEPARATOR "default" PATH_SEPARATOR "geom.glsl", &res));
 	}
 
-	// appState->shaders.textureBake = new Shader(ReadShaderSourceFile(appState->constants.shadersDir + PATH_SEPERATOR "texture_bake" PATH_SEPERATOR "vert.glsl", &res),
-	//        ReadShaderSourceFile(appState->constants.shadersDir + PATH_SEPERATOR "texture_bake" PATH_SEPERATOR "frag.glsl", &res),
-	//        ReadShaderSourceFile(appState->constants.shadersDir + PATH_SEPERATOR "texture_bake" PATH_SEPERATOR "geom.glsl", &res));
+	// appState->shaders.textureBake = new Shader(ReadShaderSourceFile(appState->constants.shadersDir + PATH_SEPARATOR "texture_bake" PATH_SEPARATOR "vert.glsl", &res),
+	//        ReadShaderSourceFile(appState->constants.shadersDir + PATH_SEPARATOR "texture_bake" PATH_SEPARATOR "frag.glsl", &res),
+	//        ReadShaderSourceFile(appState->constants.shadersDir + PATH_SEPARATOR "texture_bake" PATH_SEPARATOR "geom.glsl", &res));
 
-	// appState->shaders.terrain = new Shader(ReadShaderSourceFile(appState->constants.shadersDir + PATH_SEPERATOR "default" PATH_SEPERATOR "vert.glsl", &res),
-	//                                     ReadShaderSourceFile(appState->constants.shadersDir + PATH_SEPERATOR "default" PATH_SEPERATOR "frag.glsl", &res),
-	//                                       ReadShaderSourceFile(appState->constants.shadersDir + PATH_SEPERATOR "default" PATH_SEPERATOR "geom.glsl", &res));
+	// appState->shaders.terrain = new Shader(ReadShaderSourceFile(appState->constants.shadersDir + PATH_SEPARATOR "default" PATH_SEPARATOR "vert.glsl", &res),
+	//                                     ReadShaderSourceFile(appState->constants.shadersDir + PATH_SEPARATOR "default" PATH_SEPARATOR "frag.glsl", &res),
+	//                                       ReadShaderSourceFile(appState->constants.shadersDir + PATH_SEPARATOR "default" PATH_SEPARATOR "geom.glsl", &res));
 
-	appState->shaders.foliage = new Shader(ReadShaderSourceFile(appState->constants.shadersDir + PATH_SEPERATOR "foliage" PATH_SEPERATOR "vert.glsl", &res),
-	                                       ReadShaderSourceFile(appState->constants.shadersDir + PATH_SEPERATOR "foliage" PATH_SEPERATOR "frag.glsl", &res),
-	                                       ReadShaderSourceFile(appState->constants.shadersDir + PATH_SEPERATOR "foliage" PATH_SEPERATOR "geom.glsl", &res));
+	appState->shaders.foliage = new Shader(ReadShaderSourceFile(appState->constants.shadersDir + PATH_SEPARATOR "foliage" PATH_SEPARATOR "vert.glsl", &res),
+	                                       ReadShaderSourceFile(appState->constants.shadersDir + PATH_SEPARATOR "foliage" PATH_SEPARATOR "frag.glsl", &res),
+	                                       ReadShaderSourceFile(appState->constants.shadersDir + PATH_SEPARATOR "foliage" PATH_SEPARATOR "geom.glsl", &res));
 }
 
 static void RegenerateMesh()
@@ -284,12 +284,12 @@ static void ChangeCustomModel(std::string mdstr = ShowOpenFileDialog("*.obj"))
 static void ShowChooseBaseModelPopup()
 {
 	// TEMP
-	static std::shared_ptr<Texture2D> plane = std::make_shared<Texture2D>(appState->constants.texturesDir + PATH_SEPERATOR "ui_thumbs" PATH_SEPERATOR "plane.png", false, false);
-	static std::shared_ptr<Texture2D> sphere = std::make_shared<Texture2D>(appState->constants.texturesDir + PATH_SEPERATOR "ui_thumbs" PATH_SEPERATOR "sphere.png", false, false);
-	static std::shared_ptr<Texture2D> cube = std::make_shared<Texture2D>(appState->constants.texturesDir + PATH_SEPERATOR "ui_thumbs" PATH_SEPERATOR "cube.png", false, false);
-	static std::shared_ptr<Texture2D> cone = std::make_shared<Texture2D>(appState->constants.texturesDir + PATH_SEPERATOR "ui_thumbs" PATH_SEPERATOR "cone.png", false, false);
-	static std::shared_ptr<Texture2D> cyllinder = std::make_shared<Texture2D>(appState->constants.texturesDir + PATH_SEPERATOR "ui_thumbs" PATH_SEPERATOR "cylinder.png", false, false);
-	static std::shared_ptr<Texture2D> torus = std::make_shared<Texture2D>(appState->constants.texturesDir + PATH_SEPERATOR "ui_thumbs" PATH_SEPERATOR "torus.png", false, false);
+	static std::shared_ptr<Texture2D> plane = std::make_shared<Texture2D>(appState->constants.texturesDir + PATH_SEPARATOR "ui_thumbs" PATH_SEPARATOR "plane.png", false, false);
+	static std::shared_ptr<Texture2D> sphere = std::make_shared<Texture2D>(appState->constants.texturesDir + PATH_SEPARATOR "ui_thumbs" PATH_SEPARATOR "sphere.png", false, false);
+	static std::shared_ptr<Texture2D> cube = std::make_shared<Texture2D>(appState->constants.texturesDir + PATH_SEPARATOR "ui_thumbs" PATH_SEPARATOR "cube.png", false, false);
+	static std::shared_ptr<Texture2D> cone = std::make_shared<Texture2D>(appState->constants.texturesDir + PATH_SEPARATOR "ui_thumbs" PATH_SEPARATOR "cone.png", false, false);
+	static std::shared_ptr<Texture2D> cyllinder = std::make_shared<Texture2D>(appState->constants.texturesDir + PATH_SEPARATOR "ui_thumbs" PATH_SEPARATOR "cylinder.png", false, false);
+	static std::shared_ptr<Texture2D> torus = std::make_shared<Texture2D>(appState->constants.texturesDir + PATH_SEPARATOR "ui_thumbs" PATH_SEPARATOR "torus.png", false, false);
 	// TEMP
 
 	if (ImGui::BeginPopup("Choose Base Model"))
@@ -322,7 +322,7 @@ static void ShowChooseBaseModelPopup()
 
 		if (ImGui::ImageButton((ImTextureID)sphere->GetRendererID(), ImVec2(200, 200)))
 		{
-			ChangeCustomModel(appState->constants.modelsDir + PATH_SEPERATOR "Sphere.obj");
+			ChangeCustomModel(appState->constants.modelsDir + PATH_SEPARATOR "Sphere.obj");
 			ImGui::CloseCurrentPopup();
 		}
 
@@ -330,13 +330,13 @@ static void ShowChooseBaseModelPopup()
 
 		if (ImGui::ImageButton((ImTextureID)cube->GetRendererID(), ImVec2(200, 200)))
 		{
-			ChangeCustomModel(appState->constants.modelsDir + PATH_SEPERATOR "cube.obj");
+			ChangeCustomModel(appState->constants.modelsDir + PATH_SEPARATOR "cube.obj");
 			ImGui::CloseCurrentPopup();
 		}
 
 		if (ImGui::ImageButton((ImTextureID)torus->GetRendererID(), ImVec2(200, 200)))
 		{
-			ChangeCustomModel(appState->constants.modelsDir + PATH_SEPERATOR "Torus.obj");
+			ChangeCustomModel(appState->constants.modelsDir + PATH_SEPARATOR "Torus.obj");
 			ImGui::CloseCurrentPopup();
 		}
 
@@ -344,7 +344,7 @@ static void ShowChooseBaseModelPopup()
 
 		if (ImGui::ImageButton((ImTextureID)cone->GetRendererID(), ImVec2(200, 200)))
 		{
-			ChangeCustomModel(appState->constants.modelsDir + PATH_SEPERATOR "cone.obj");
+			ChangeCustomModel(appState->constants.modelsDir + PATH_SEPARATOR "cone.obj");
 			ImGui::CloseCurrentPopup();
 		}
 
@@ -352,7 +352,7 @@ static void ShowChooseBaseModelPopup()
 
 		if (ImGui::ImageButton((ImTextureID)cyllinder->GetRendererID(), ImVec2(200, 200)))
 		{
-			ChangeCustomModel(appState->constants.modelsDir + PATH_SEPERATOR "cylinder.obj");
+			ChangeCustomModel(appState->constants.modelsDir + PATH_SEPARATOR "cylinder.obj");
 			ImGui::CloseCurrentPopup();
 		}
 
@@ -680,11 +680,11 @@ public:
 	virtual void OnPreload() override
 	{
 		SetTitle("TerraForge3D - Jaysmito Mukherjee");
-		MkDir(GetExecutableDir() + PATH_SEPERATOR "Data" PATH_SEPERATOR "logs");
-		SetLogsDir(GetExecutableDir() + PATH_SEPERATOR "Data" PATH_SEPERATOR "logs");
-		SetWindowConfigPath(GetExecutableDir() + PATH_SEPERATOR "Data" PATH_SEPERATOR "configs" PATH_SEPERATOR "windowconfigs.terr3d");
-		MkDir(GetExecutableDir() + PATH_SEPERATOR "Data" PATH_SEPERATOR "cache" PATH_SEPERATOR "autosave\"");
-		MkDir(GetExecutableDir() + PATH_SEPERATOR "Data" PATH_SEPERATOR "temp\"");
+		MkDir(GetExecutableDir() + PATH_SEPARATOR "Data" PATH_SEPARATOR "logs");
+		SetLogsDir(GetExecutableDir() + PATH_SEPARATOR "Data" PATH_SEPARATOR "logs");
+		SetWindowConfigPath(GetExecutableDir() + PATH_SEPARATOR "Data" PATH_SEPARATOR "configs" PATH_SEPARATOR "windowconfigs.terr3d");
+		MkDir(GetExecutableDir() + PATH_SEPARATOR "Data" PATH_SEPARATOR "cache" PATH_SEPARATOR "autosave\"");
+		MkDir(GetExecutableDir() + PATH_SEPARATOR "Data" PATH_SEPARATOR "temp\"");
 	}
 
 	virtual void OnUpdate(float deltatime) override
@@ -848,7 +848,7 @@ public:
 		{
 			if (appState->states.autoSave)
 			{
-				SaveFile(appState->constants.cacheDir + PATH_SEPERATOR "autosave" PATH_SEPERATOR "autosave.terr3d");
+				SaveFile(appState->constants.cacheDir + PATH_SEPARATOR "autosave" PATH_SEPARATOR "autosave.terr3d");
 
 				if (appState->globals.currentOpenFilePath.size() > 3)
 				{
@@ -956,20 +956,20 @@ public:
 		appState = new ApplicationState();
 		appState->mainApp = mainApp;
 		appState->constants.executableDir = GetExecutableDir();
-		appState->constants.dataDir = appState->constants.executableDir + PATH_SEPERATOR "Data";
-		appState->constants.cacheDir = appState->constants.dataDir  	+ PATH_SEPERATOR "cache";
-		appState->constants.texturesDir = appState->constants.dataDir  	+ PATH_SEPERATOR "textures";
-		appState->constants.projectsDir = appState->constants.cacheDir  + PATH_SEPERATOR "project_data";
-		appState->constants.tempDir = appState->constants.dataDir  		+ PATH_SEPERATOR "temp";
-		appState->constants.shadersDir = appState->constants.dataDir  	+ PATH_SEPERATOR "shaders";
-		appState->constants.kernelsDir = appState->constants.dataDir  	+ PATH_SEPERATOR "kernels";
-		appState->constants.fontsDir = appState->constants.dataDir  	+ PATH_SEPERATOR "fonts";
-		appState->constants.liscensesDir = appState->constants.dataDir 	+ PATH_SEPERATOR "licenses";
-		appState->constants.skyboxDir = appState->constants.dataDir  	+ PATH_SEPERATOR "skybox";
-		appState->constants.modulesDir = appState->constants.dataDir  	+ PATH_SEPERATOR "modules";
-		appState->constants.configsDir = appState->constants.dataDir  	+ PATH_SEPERATOR "configs";
-		appState->constants.logsDir = appState->constants.dataDir  		+ PATH_SEPERATOR "logs";
-		appState->constants.modelsDir = appState->constants.dataDir  	+ PATH_SEPERATOR "models";
+		appState->constants.dataDir = appState->constants.executableDir + PATH_SEPARATOR "Data";
+		appState->constants.cacheDir = appState->constants.dataDir  	+ PATH_SEPARATOR "cache";
+		appState->constants.texturesDir = appState->constants.dataDir  	+ PATH_SEPARATOR "textures";
+		appState->constants.projectsDir = appState->constants.cacheDir  + PATH_SEPARATOR "project_data";
+		appState->constants.tempDir = appState->constants.dataDir  		+ PATH_SEPARATOR "temp";
+		appState->constants.shadersDir = appState->constants.dataDir  	+ PATH_SEPARATOR "shaders";
+		appState->constants.kernelsDir = appState->constants.dataDir  	+ PATH_SEPARATOR "kernels";
+		appState->constants.fontsDir = appState->constants.dataDir  	+ PATH_SEPARATOR "fonts";
+		appState->constants.liscensesDir = appState->constants.dataDir 	+ PATH_SEPARATOR "licenses";
+		appState->constants.skyboxDir = appState->constants.dataDir  	+ PATH_SEPARATOR "skybox";
+		appState->constants.modulesDir = appState->constants.dataDir  	+ PATH_SEPARATOR "modules";
+		appState->constants.configsDir = appState->constants.dataDir  	+ PATH_SEPARATOR "configs";
+		appState->constants.logsDir = appState->constants.dataDir  		+ PATH_SEPARATOR "logs";
+		appState->constants.modelsDir = appState->constants.dataDir  	+ PATH_SEPARATOR "models";
 		appState->supportersTribute = new SupportersTribute();
 		SetupExplorerControls();
 		ImGui::GetStyle().WindowMenuButtonPosition = ImGuiDir_None;
@@ -1034,9 +1034,9 @@ public:
 		appState->filtersManager = new FiltersManager(appState);
 		float t = 1.0f;
 		// Load Fonts
-		LoadUIFont("Open-Sans-Regular", 18, appState->constants.fontsDir + PATH_SEPERATOR "OpenSans-Regular.ttf");
-		LoadUIFont("OpenSans-Bold", 25, appState->constants.fontsDir + PATH_SEPERATOR "OpenSans-Bold.ttf");
-		LoadUIFont("OpenSans-Semi-Bold", 22, appState->constants.fontsDir + PATH_SEPERATOR "OpenSans-Bold.ttf");
+		LoadUIFont("Open-Sans-Regular", 18, appState->constants.fontsDir + PATH_SEPARATOR "OpenSans-Regular.ttf");
+		LoadUIFont("OpenSans-Bold", 25, appState->constants.fontsDir + PATH_SEPARATOR "OpenSans-Bold.ttf");
+		LoadUIFont("OpenSans-Semi-Bold", 22, appState->constants.fontsDir + PATH_SEPARATOR "OpenSans-Bold.ttf");
 		// The framebuffer used for reflections in the sea
 		appState->frameBuffers.reflection = new FrameBuffer();
 		// The main frame buffer
@@ -1044,24 +1044,24 @@ public:
 		// The Framebuffer used for post processing
 		appState->frameBuffers.postProcess = new FrameBuffer(1280, 720);
 		bool tpp = false;
-		appState->shaders.postProcess = new Shader(ReadShaderSourceFile(appState->constants.shadersDir + PATH_SEPERATOR "post_processing" PATH_SEPERATOR "vert.glsl", &tpp),
-		        ReadShaderSourceFile(appState->constants.shadersDir + PATH_SEPERATOR "post_processing" PATH_SEPERATOR "frag.glsl", &tpp));
+		appState->shaders.postProcess = new Shader(ReadShaderSourceFile(appState->constants.shadersDir + PATH_SEPARATOR "post_processing" PATH_SEPARATOR "vert.glsl", &tpp),
+		        ReadShaderSourceFile(appState->constants.shadersDir + PATH_SEPARATOR "post_processing" PATH_SEPARATOR "frag.glsl", &tpp));
 		appState->states.autoUpdate = true;
 
 		if(IsNetWorkConnected())
 		{
-			if(FileExists(appState->constants.configsDir + PATH_SEPERATOR "server.terr3d"))
+			if(FileExists(appState->constants.configsDir + PATH_SEPARATOR "server.terr3d"))
 			{
 				bool ttmp = false;
-				std::string uid = ReadShaderSourceFile(appState->constants.configsDir + PATH_SEPERATOR "server.terr3d", &ttmp);
+				std::string uid = ReadShaderSourceFile(appState->constants.configsDir + PATH_SEPARATOR "server.terr3d", &ttmp);
 				Log("Connection to Backend : " + FetchURL("https://terraforge3d.maxalpha.repl.co", "/startup/" + uid));
 			}
 
 			else
 			{
-				DownloadFile("https://terraforge3d.maxalpha.repl.co", "/register", appState->constants.configsDir + PATH_SEPERATOR "server.terr3d");
+				DownloadFile("https://terraforge3d.maxalpha.repl.co", "/register", appState->constants.configsDir + PATH_SEPARATOR "server.terr3d");
 				bool ttmp = false;
-				std::string uid = ReadShaderSourceFile(appState->constants.configsDir + PATH_SEPERATOR "server.terr3d", &ttmp);
+				std::string uid = ReadShaderSourceFile(appState->constants.configsDir + PATH_SEPARATOR "server.terr3d", &ttmp);
 				Log("Connection to Backend : " + FetchURL("https://terraforge3d.maxalpha.repl.co", "/startup/" + uid));
 			}
 		}

--- a/TerraForge3D/src/Menu/MainMenu.cpp
+++ b/TerraForge3D/src/Menu/MainMenu.cpp
@@ -6,6 +6,7 @@
 #include "Misc/AppStyles.h"
 #include "Misc/ExportManager.h"
 #include "Data/ApplicationState.h"
+#include "Platform.h"
 
 static void ShowWindowMenuItem(const char *title, bool *val)
 {
@@ -151,7 +152,7 @@ void MainMenu::ShowFileMenu()
 
 	if (ImGui::MenuItem("Load Auto Saved Project"))
 	{
-		appState->serailizer->LoadFile(GetExecutableDir() + "\\Data\\cache\\autosave\\autosave.terr3d");
+		appState->serailizer->LoadFile(GetExecutableDir() + PATH_SEPARATOR "Data" PATH_SEPARATOR "cache" PATH_SEPARATOR "autosave" PATH_SEPARATOR "autosave.terr3d");
 	}
 
 	if (ImGui::MenuItem("Exit"))

--- a/TerraForge3D/src/Misc/SupportersTribute.cpp
+++ b/TerraForge3D/src/Misc/SupportersTribute.cpp
@@ -3,6 +3,7 @@
 #include "Misc/SupportersTribute.h"
 
 #include "Base/Texture2D.h"
+#include "Platform.h"
 
 #include <Utils.h>
 #include <imgui.h>
@@ -20,20 +21,20 @@ void SupportersTribute::LoadstargazersData(nlohmann::json &data)
 		GitHubData st;
 		st.name = item["login"];
 
-		if (!PathExist(GetExecutableDir() + "\\Data\\cache\\github_avatars"))
+		if (!PathExist(GetExecutableDir() + PATH_SEPARATOR "Data" PATH_SEPARATOR "cache" PATH_SEPARATOR "github_avatars"))
 		{
-			MkDir(GetExecutableDir() + "\\Data\\cache\\github_avatars");
+			MkDir(GetExecutableDir() + PATH_SEPARATOR "Data" PATH_SEPARATOR "cache" PATH_SEPARATOR "github_avatars");
 		}
 
-		if (!FileExists(GetExecutableDir() + "\\Data\\cache\\github_avatars\\" + st.name + "_" + std::string(item["node_id"])) && isNetWorkConnected)
+		if (!FileExists(GetExecutableDir() + PATH_SEPARATOR "Data" PATH_SEPARATOR "cache" PATH_SEPARATOR "github_avatars" + PATH_SEPARATOR + st.name + "_" + std::string(item["node_id"])) && isNetWorkConnected)
 		{
 			std::string urlFull = item["avatar_url"];
 			std::string baseURL = urlFull.substr(0, 37);
 			std::string pathURL = urlFull.substr(38);
-			DownloadFile(baseURL, pathURL, GetExecutableDir() + "\\Data\\cache\\github_avatars\\" + st.name + "_" + std::string(item["node_id"]));
+			DownloadFile(baseURL, pathURL, GetExecutableDir() + PATH_SEPARATOR "Data" PATH_SEPARATOR "cache" PATH_SEPARATOR "github_avatars" + PATH_SEPARATOR + st.name + "_" + std::string(item["node_id"]));
 		}
 
-		st.avatar = new Texture2D(GetExecutableDir() + "\\Data\\cache\\github_avatars\\" + st.name + "_" + std::string(item["node_id"]));
+		st.avatar = new Texture2D(GetExecutableDir() + PATH_SEPARATOR "Data" PATH_SEPARATOR "cache" PATH_SEPARATOR "github_avatars" + PATH_SEPARATOR + st.name + "_" + std::string(item["node_id"]));
 		stargazers.push_back(st);
 	}
 }
@@ -47,20 +48,27 @@ void SupportersTribute::LoadcontributorsData(nlohmann::json &data)
 		GitHubData st;
 		st.name = item["login"];
 
-		if (!PathExist(GetExecutableDir() + "\\Data\\cache\\github_avatars"))
+		if (!PathExist(GetExecutableDir() + PATH_SEPARATOR "Data" PATH_SEPARATOR "cache" PATH_SEPARATOR "github_avatars"))
 		{
-			MkDir(GetExecutableDir() + "\\Data\\cache\\github_avatars");
+			MkDir(GetExecutableDir() + PATH_SEPARATOR "Data" + PATH_SEPARATOR
+					+ "cache" PATH_SEPARATOR "github_avatars");
 		}
 
-		if (!FileExists(GetExecutableDir() + "\\Data\\cache\\github_avatars\\" + st.name + "_" + std::string(item["node_id"])) && isNetWorkConnected)
+		if (!FileExists(GetExecutableDir() + PATH_SEPARATOR "Data" PATH_SEPARATOR "cache" PATH_SEPARATOR "github_avatars" + PATH_SEPARATOR + st.name + "_" + std::string(item["node_id"])) && isNetWorkConnected)
 		{
 			std::string urlFull = item["avatar_url"];
 			std::string baseURL = urlFull.substr(0, 37);
 			std::string pathURL = urlFull.substr(38);
-			DownloadFile(baseURL, pathURL, GetExecutableDir() + "\\Data\\cache\\github_avatars\\" + st.name + "_" + std::string(item["node_id"]));
+			DownloadFile(baseURL, pathURL, GetExecutableDir() + PATH_SEPARATOR
+					+ "Data" PATH_SEPARATOR "cache" + PATH_SEPARATOR +
+					"github_avatars" + PATH_SEPARATOR + st.name + "_" +
+					std::string(item["node_id"]));
 		}
 
-		st.avatar = new Texture2D(GetExecutableDir() + "\\Data\\cache\\github_avatars\\" + st.name + "_" + std::string(item["node_id"]));
+		st.avatar = new Texture2D(GetExecutableDir() + PATH_SEPARATOR "Data"
+				+ PATH_SEPARATOR "cache" PATH_SEPARATOR "github_avatars"
+				+ PATH_SEPARATOR + st.name + "_" +
+				std::string(item["node_id"]));
 		contributors.push_back(st);
 	}
 }
@@ -68,7 +76,7 @@ void SupportersTribute::LoadcontributorsData(nlohmann::json &data)
 
 SupportersTribute::SupportersTribute()
 {
-	if (IsNetWorkConnected() && (!FileExists(GetExecutableDir() + "\\Data\\cache\\stargazers.terr3dcache") || rand() % 5 == 0))
+	if (IsNetWorkConnected() && (!FileExists(GetExecutableDir() + PATH_SEPARATOR "Data" PATH_SEPARATOR "cache" PATH_SEPARATOR "stargazers.terr3dcache") || rand() % 5 == 0))
 	{
 		Log("Internet Connection is Live!\nFetching Latest Supporters data.");
 		{
@@ -78,13 +86,13 @@ SupportersTribute::SupportersTribute()
 			int perPage = 30;
 			int lastPage = stargazerCount / perPage;
 			std::string stargazersRawData = FetchURL("https://api.github.com", "/repos/Jaysmito101/TerraForge3D/stargazers?per_page=30&page=" + std::to_string(lastPage));
-			SaveToFile(GetExecutableDir() + "\\Data\\cache\\stargazers.terr3dcache", stargazersRawData);
+			SaveToFile(GetExecutableDir() + PATH_SEPARATOR +"Data" PATH_SEPARATOR "cache" PATH_SEPARATOR "stargazers.terr3dcache", stargazersRawData);
 			nlohmann::json stargazersData = nlohmann::json::parse(stargazersRawData);
 			LoadstargazersData(stargazersData);
 		}
 		{
 			std::string contributorsRawData = FetchURL("https://api.github.com", "/repos/Jaysmito101/TerraForge3D/contributors");
-			SaveToFile(GetExecutableDir() + "\\Data\\cache\\contributors.terr3dcache", contributorsRawData);
+			SaveToFile(GetExecutableDir() + PATH_SEPARATOR "Data" PATH_SEPARATOR "cache" PATH_SEPARATOR "contributors.terr3dcache", contributorsRawData);
 			nlohmann::json contributorsData = nlohmann::json::parse(contributorsRawData);
 			LoadcontributorsData(contributorsData);
 		}
@@ -95,10 +103,10 @@ SupportersTribute::SupportersTribute()
 		bool tmp = false;
 		Log("Trying to load cached data.");
 
-		if (FileExists(GetExecutableDir() + "\\Data\\cache\\stargazers.terr3dcache"))
+		if (FileExists(GetExecutableDir() + PATH_SEPARATOR "Data"+ PATH_SEPARATOR "cache" PATH_SEPARATOR "stargazers.terr3dcache"))
 		{
 			Log("Found Stargazers Cached Data!");
-			std::string stargazersRawData = ReadShaderSourceFile(GetExecutableDir() + "\\Data\\cache\\stargazers.terr3dcache", &tmp);
+			std::string stargazersRawData = ReadShaderSourceFile(GetExecutableDir() + PATH_SEPARATOR "Data" PATH_SEPARATOR "cache" PATH_SEPARATOR "stargazers.terr3dcache", &tmp);
 			nlohmann::json stargazersData = nlohmann::json::parse(stargazersRawData);
 			LoadstargazersData(stargazersData);
 		}
@@ -108,10 +116,10 @@ SupportersTribute::SupportersTribute()
 			Log("Stargazers Cached Data not found!");
 		}
 
-		if (FileExists(GetExecutableDir() + "\\Data\\cache\\contributors.terr3dcache"))
+		if (FileExists(GetExecutableDir() + PATH_SEPARATOR "Data" PATH_SEPARATOR "cache" PATH_SEPARATOR "contributors.terr3dcache"))
 		{
 			Log("Found Contributors Cached Data!");
-			std::string contributorsRawData = ReadShaderSourceFile(GetExecutableDir() + "\\Data\\cache\\contributors.terr3dcache", &tmp);
+			std::string contributorsRawData = ReadShaderSourceFile(GetExecutableDir() + PATH_SEPARATOR "Data" PATH_SEPARATOR "cache" PATH_SEPARATOR "contributors.terr3dcache", &tmp);
 			nlohmann::json contributorsData = nlohmann::json::parse(contributorsRawData);
 			LoadcontributorsData(contributorsData);
 		}

--- a/TerraForge3D/src/Misc/SupportersTribute.cpp
+++ b/TerraForge3D/src/Misc/SupportersTribute.cpp
@@ -26,15 +26,15 @@ void SupportersTribute::LoadstargazersData(nlohmann::json &data)
 			MkDir(GetExecutableDir() + PATH_SEPARATOR "Data" PATH_SEPARATOR "cache" PATH_SEPARATOR "github_avatars");
 		}
 
-		if (!FileExists(GetExecutableDir() + PATH_SEPARATOR "Data" PATH_SEPARATOR "cache" PATH_SEPARATOR "github_avatars" + PATH_SEPARATOR + st.name + "_" + std::string(item["node_id"])) && isNetWorkConnected)
+		if (!FileExists(GetExecutableDir() + PATH_SEPARATOR "Data" PATH_SEPARATOR "cache" PATH_SEPARATOR "github_avatars" PATH_SEPARATOR + st.name + "_" + std::string(item["node_id"])) && isNetWorkConnected)
 		{
 			std::string urlFull = item["avatar_url"];
 			std::string baseURL = urlFull.substr(0, 37);
 			std::string pathURL = urlFull.substr(38);
-			DownloadFile(baseURL, pathURL, GetExecutableDir() + PATH_SEPARATOR "Data" PATH_SEPARATOR "cache" PATH_SEPARATOR "github_avatars" + PATH_SEPARATOR + st.name + "_" + std::string(item["node_id"]));
+			DownloadFile(baseURL, pathURL, GetExecutableDir() + PATH_SEPARATOR "Data" PATH_SEPARATOR "cache" PATH_SEPARATOR "github_avatars" PATH_SEPARATOR + st.name + "_" + std::string(item["node_id"]));
 		}
 
-		st.avatar = new Texture2D(GetExecutableDir() + PATH_SEPARATOR "Data" PATH_SEPARATOR "cache" PATH_SEPARATOR "github_avatars" + PATH_SEPARATOR + st.name + "_" + std::string(item["node_id"]));
+		st.avatar = new Texture2D(GetExecutableDir() + PATH_SEPARATOR "Data" PATH_SEPARATOR "cache" PATH_SEPARATOR "github_avatars" PATH_SEPARATOR + st.name + "_" + std::string(item["node_id"]));
 		stargazers.push_back(st);
 	}
 }
@@ -50,24 +50,23 @@ void SupportersTribute::LoadcontributorsData(nlohmann::json &data)
 
 		if (!PathExist(GetExecutableDir() + PATH_SEPARATOR "Data" PATH_SEPARATOR "cache" PATH_SEPARATOR "github_avatars"))
 		{
-			MkDir(GetExecutableDir() + PATH_SEPARATOR "Data" + PATH_SEPARATOR
-					+ "cache" PATH_SEPARATOR "github_avatars");
+			MkDir(GetExecutableDir() + PATH_SEPARATOR "Data" PATH_SEPARATOR "cache" PATH_SEPARATOR "github_avatars");
 		}
 
-		if (!FileExists(GetExecutableDir() + PATH_SEPARATOR "Data" PATH_SEPARATOR "cache" PATH_SEPARATOR "github_avatars" + PATH_SEPARATOR + st.name + "_" + std::string(item["node_id"])) && isNetWorkConnected)
+		if (!FileExists(GetExecutableDir() + PATH_SEPARATOR "Data" PATH_SEPARATOR "cache" PATH_SEPARATOR "github_avatars" PATH_SEPARATOR + st.name + "_" + std::string(item["node_id"])) && isNetWorkConnected)
 		{
 			std::string urlFull = item["avatar_url"];
 			std::string baseURL = urlFull.substr(0, 37);
 			std::string pathURL = urlFull.substr(38);
 			DownloadFile(baseURL, pathURL, GetExecutableDir() + PATH_SEPARATOR
-					+ "Data" PATH_SEPARATOR "cache" + PATH_SEPARATOR +
-					"github_avatars" + PATH_SEPARATOR + st.name + "_" +
+					"Data" PATH_SEPARATOR "cache" PATH_SEPARATOR
+					"github_avatars" PATH_SEPARATOR + st.name + "_" +
 					std::string(item["node_id"]));
 		}
 
 		st.avatar = new Texture2D(GetExecutableDir() + PATH_SEPARATOR "Data"
-				+ PATH_SEPARATOR "cache" PATH_SEPARATOR "github_avatars"
-				+ PATH_SEPARATOR + st.name + "_" +
+				PATH_SEPARATOR "cache" PATH_SEPARATOR "github_avatars"
+				PATH_SEPARATOR + st.name + "_" +
 				std::string(item["node_id"]));
 		contributors.push_back(st);
 	}
@@ -103,7 +102,7 @@ SupportersTribute::SupportersTribute()
 		bool tmp = false;
 		Log("Trying to load cached data.");
 
-		if (FileExists(GetExecutableDir() + PATH_SEPARATOR "Data"+ PATH_SEPARATOR "cache" PATH_SEPARATOR "stargazers.terr3dcache"))
+		if (FileExists(GetExecutableDir() + PATH_SEPARATOR "Data" PATH_SEPARATOR "cache" PATH_SEPARATOR "stargazers.terr3dcache"))
 		{
 			Log("Found Stargazers Cached Data!");
 			std::string stargazersRawData = ReadShaderSourceFile(GetExecutableDir() + PATH_SEPARATOR "Data" PATH_SEPARATOR "cache" PATH_SEPARATOR "stargazers.terr3dcache", &tmp);

--- a/TerraForge3D/src/Modules/ModuleManager.cpp
+++ b/TerraForge3D/src/Modules/ModuleManager.cpp
@@ -44,13 +44,13 @@ void ModuleManager::LoadModules()
 {
 	UnloadModules();
 	// iterate through all directories in the modules folder
-	std::string modulesFolder = appState->constants.modulesDir + PATH_SEPERATOR;
+	std::string modulesFolder = appState->constants.modulesDir + PATH_SEPARATOR;
 	for (auto &p : std::filesystem::directory_iterator(modulesFolder))
 	{
 		std::string path = p.path().string();
-		if (p.is_directory() && FileExists(path + PATH_SEPERATOR + "module" MODULE_EXT ))
+		if (p.is_directory() && FileExists(path + PATH_SEPARATOR "module" MODULE_EXT ))
 		{
-			LoadModule(path + PATH_SEPERATOR + "module" MODULE_EXT);
+			LoadModule(path + PATH_SEPARATOR "module" MODULE_EXT);
 		}
 	}
 }
@@ -113,9 +113,9 @@ ModuleManager::~ModuleManager()
 void ModuleManager::InstallModule(std::string path)
 {
 	// extract zip file to modules folder
-	zip_extract(path.data(), (appState->constants.modulesDir + PATH_SEPERATOR + GenerateId(32)).data(), [](const char* f, void* arg){return 1;}, 0);
+	zip_extract(path.data(), (appState->constants.modulesDir + PATH_SEPARATOR + GenerateId(32)).data(), [](const char* f, void* arg){return 1;}, 0);
 	// load module
-	LoadModule(appState->constants.modulesDir + PATH_SEPERATOR + GenerateId(32) + PATH_SEPERATOR + "module" MODULE_EXT);
+	LoadModule(appState->constants.modulesDir + PATH_SEPARATOR + GenerateId(32) + PATH_SEPARATOR "module" MODULE_EXT);
 }
 
 void ModuleManager::UninstallModule(std::string uid)

--- a/TerraForge3D/src/Sea/SeaManager.cpp
+++ b/TerraForge3D/src/Sea/SeaManager.cpp
@@ -23,12 +23,12 @@ SeaManager::SeaManager(ApplicationState *as)
 	color[2] = 0.7f;
 	color[3] = 0;
 	scale = 100;
-	std::string vertexShaderSource = ReadShaderSourceFile(GetExecutableDir() + "\\Data\\shaders\\water\\vert.glsl", &tmp);
-	std::string fragmentShaderSource = ReadShaderSourceFile(GetExecutableDir() + "\\Data\\shaders\\water\\frag.glsl", &tmp);
-	std::string geometryShaderSource = ReadShaderSourceFile(GetExecutableDir() + "\\Data\\shaders\\water\\geom.glsl", &tmp);
+	std::string vertexShaderSource = ReadShaderSourceFile(GetExecutableDir() + PATH_SEPARATOR "Data" PATH_SEPARATOR "shaders" PATH_SEPARATOR "water" PATH_SEPARATOR "vert.glsl", &tmp);
+	std::string fragmentShaderSource = ReadShaderSourceFile(GetExecutableDir() + PATH_SEPARATOR "Data" PATH_SEPARATOR "shaders" PATH_SEPARATOR "water" PATH_SEPARATOR "frag.glsl", &tmp);
+	std::string geometryShaderSource = ReadShaderSourceFile(GetExecutableDir() + PATH_SEPARATOR "Data" PATH_SEPARATOR "shaders" PATH_SEPARATOR "water" PATH_SEPARATOR "geom.glsl", &tmp);
 	shader = new Shader(vertexShaderSource, fragmentShaderSource, geometryShaderSource);
-	dudvMap = new Texture2D(GetExecutableDir() + PATH_SEPERATOR "Data" PATH_SEPERATOR "textures" PATH_SEPERATOR "water_dudv.png");
-	normalMap = new Texture2D(GetExecutableDir() + PATH_SEPERATOR "Data" PATH_SEPERATOR "textures" PATH_SEPERATOR "water_normal.png");
+	dudvMap = new Texture2D(GetExecutableDir() + PATH_SEPARATOR "Data" PATH_SEPARATOR "textures" PATH_SEPARATOR "water_dudv.png");
+	normalMap = new Texture2D(GetExecutableDir() + PATH_SEPARATOR "Data" PATH_SEPARATOR "textures" PATH_SEPARATOR "water_normal.png");
 }
 
 SeaManager::~SeaManager()
@@ -72,14 +72,14 @@ void SeaManager::Load(nlohmann::json data)
 		delete dudvMap;
 	}
 
-	dudvMap = new Texture2D(appState->projectManager->GetResourcePath() + "\\" + appState->projectManager->GetAsset(data["dudvMap"]));
+	dudvMap = new Texture2D(appState->projectManager->GetResourcePath() + PATH_SEPARATOR + appState->projectManager->GetAsset(data["dudvMap"]));
 
 	if (normalMap)
 	{
 		delete normalMap;
 	}
 
-	normalMap = new Texture2D(appState->projectManager->GetResourcePath() + "\\" + appState->projectManager->GetAsset(data["normalMap"]));
+	normalMap = new Texture2D(appState->projectManager->GetResourcePath() + PATH_SEPARATOR + appState->projectManager->GetAsset(data["normalMap"]));
 }
 
 nlohmann::json SeaManager::Save()

--- a/TerraForge3D/src/Shading/ShaderNodes/ShaderTextureNode.cpp
+++ b/TerraForge3D/src/Shading/ShaderNodes/ShaderTextureNode.cpp
@@ -48,7 +48,7 @@ void ShaderTextureNode::Load(nlohmann::json data)
 		texture = nullptr;
 	}
 
-	texture = new Texture2D(ProjectManager::Get()->GetResourcePath() + PATH_SEPERATOR + ProjectManager::Get()->GetAsset(data["texture"]));
+	texture = new Texture2D(ProjectManager::Get()->GetResourcePath() + PATH_SEPARATOR + ProjectManager::Get()->GetAsset(data["texture"]));
 	scale = data["scale"];
 	offsetX = data["offsetX"];
 	offsetY = data["offsetY"];
@@ -156,7 +156,7 @@ ShaderTextureNode::ShaderTextureNode(GLSLHandler *handler, ShaderTextureManager 
 	name = "Texture";
 	headerColor = ImColor(SHADER_TEXTURE_NODE_COLOR);
 	outputPins.push_back(new SNEPin(NodeEditorPinType::Output, SNEPinType::SNEPinType_Float3));
-	texture = new Texture2D(GetExecutableDir() + PATH_SEPERATOR "Data" PATH_SEPERATOR "textures" PATH_SEPERATOR "white.png");
+	texture = new Texture2D(GetExecutableDir() + PATH_SEPARATOR "Data" PATH_SEPARATOR "textures" PATH_SEPARATOR "white.png");
 	textureManager->Register(this);
 }
 

--- a/TerraForge3D/src/Shading/ShadingManager.cpp
+++ b/TerraForge3D/src/Shading/ShadingManager.cpp
@@ -172,7 +172,7 @@ ShadingManager::ShadingManager(ApplicationState *as)
 
 		return node;
 	};
-	config.saveFile = GetExecutableDir() + PATH_SEPERATOR + "Data" + PATH_SEPERATOR + "configs" + PATH_SEPERATOR + "ShaderNodes.json";
+	config.saveFile = GetExecutableDir() + PATH_SEPARATOR "Data" PATH_SEPARATOR "configs" PATH_SEPARATOR "ShaderNodes.json";
 	shaderNodeEditor = new NodeEditor(config);
 	shaderNodeEditor->name = "Shader Nodes";
 	shaderNodeEditor->SetOutputNode(new ShaderOutputNode(fsh));
@@ -217,7 +217,7 @@ void ShadingManager::UpdateShaders()
 
 void ShadingManager::LoadDefaultCustomNodes()
 {
-	std::string nodesDir = GetExecutableDir() + PATH_SEPERATOR + "Data" + PATH_SEPERATOR + "shader_nodes";
+	std::string nodesDir = GetExecutableDir() + PATH_SEPARATOR "Data" PATH_SEPARATOR "shader_nodes";
 	defaultCustomNodes.clear();
 	bool tmp = false;
 
@@ -232,7 +232,7 @@ void ShadingManager::LoadDefaultCustomNodes()
 		defaultCustomNodes.push_back(n);
 	}
 
-	extraSource = ReadShaderSourceFile(nodesDir + PATH_SEPERATOR + "extras.glsl", &tmp);
+	extraSource = ReadShaderSourceFile(nodesDir + PATH_SEPARATOR "extras.glsl", &tmp);
 	
 }
 

--- a/TerraForge3D/src/Sky/CubeMap.cpp
+++ b/TerraForge3D/src/Sky/CubeMap.cpp
@@ -17,9 +17,9 @@
 #include "Data/ApplicationState.h"
 
 static bool tmpb = false;
-static std::string vertShader = ReadShaderSourceFile(GetExecutableDir() + PATH_SEPERATOR "Data" PATH_SEPERATOR "shaders" PATH_SEPERATOR "skybox" PATH_SEPERATOR "vert.glsl", &tmpb);
-static std::string fragShader = ReadShaderSourceFile(GetExecutableDir() + PATH_SEPERATOR "Data" PATH_SEPERATOR "shaders" PATH_SEPERATOR "skybox" PATH_SEPERATOR "frag.glsl", &tmpb);
-static std::string fragProShader = ReadShaderSourceFile(GetExecutableDir() + PATH_SEPERATOR "Data" PATH_SEPERATOR "shaders" PATH_SEPERATOR "skybox" PATH_SEPERATOR "procedural_clouds.glsl", &tmpb);
+static std::string vertShader = ReadShaderSourceFile(GetExecutableDir() + PATH_SEPARATOR "Data" PATH_SEPARATOR "shaders" PATH_SEPARATOR "skybox" PATH_SEPARATOR "vert.glsl", &tmpb);
+static std::string fragShader = ReadShaderSourceFile(GetExecutableDir() + PATH_SEPARATOR "Data" PATH_SEPARATOR "shaders" PATH_SEPARATOR "skybox" PATH_SEPARATOR "frag.glsl", &tmpb);
+static std::string fragProShader = ReadShaderSourceFile(GetExecutableDir() + PATH_SEPARATOR "Data" PATH_SEPARATOR "shaders" PATH_SEPARATOR "skybox" PATH_SEPARATOR "procedural_clouds.glsl", &tmpb);
 
 
 static float skyboxVertices[] =
@@ -96,12 +96,12 @@ CubeMapManager::CubeMapManager(ApplicationState *as)
 	appState = as;
 	static std::vector<std::string> faces =
 	{
-		appState->constants.skyboxDir + PATH_SEPERATOR "px.jpg",
-		appState->constants.skyboxDir + PATH_SEPERATOR "nx.jpg",
-		appState->constants.skyboxDir + PATH_SEPERATOR "py.jpg",
-		appState->constants.skyboxDir + PATH_SEPERATOR "ny.jpg",
-		appState->constants.skyboxDir + PATH_SEPERATOR "pz.jpg",
-		appState->constants.skyboxDir + PATH_SEPERATOR "nz.jpg"
+		appState->constants.skyboxDir + PATH_SEPARATOR "px.jpg",
+		appState->constants.skyboxDir + PATH_SEPARATOR "nx.jpg",
+		appState->constants.skyboxDir + PATH_SEPARATOR "py.jpg",
+		appState->constants.skyboxDir + PATH_SEPARATOR "ny.jpg",
+		appState->constants.skyboxDir + PATH_SEPARATOR "pz.jpg",
+		appState->constants.skyboxDir + PATH_SEPARATOR "nz.jpg"
 	};
 	cubemap = new TextureCubemap();
 	cubemap->SetUpOnGPU();
@@ -117,7 +117,7 @@ CubeMapManager::CubeMapManager(ApplicationState *as)
 	glBufferData(GL_ARRAY_BUFFER, sizeof(skyboxVertices), skyboxVertices, GL_STATIC_DRAW);
 	glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 3 * sizeof(float), (void *)0);
 	glEnableVertexAttribArray(0);
-	skySphere = LoadModel(GetExecutableDir() + PATH_SEPERATOR "Data" PATH_SEPERATOR "models" PATH_SEPERATOR "icosphere.obj");
+	skySphere = LoadModel(GetExecutableDir() + PATH_SEPARATOR "Data" PATH_SEPARATOR "models" PATH_SEPARATOR "icosphere.obj");
 	skySphere->SetupMeshOnGPU();
 	skySphere->UploadToGPU();
 }

--- a/TerraForge3D/src/TextureStore/TextureStore.cpp
+++ b/TerraForge3D/src/TextureStore/TextureStore.cpp
@@ -295,7 +295,7 @@ void TextureStore::DownloadTexture(int id, int res)
 	textureStoreItems[id].abledo = baseDir + PATH_SEPARATOR "albedo.png";
 	tmpStr = tmpJ["nor_gl"][std::to_string(res) + "k"]["png"]["url"];
 	DownloadFile("https://dl.polyhaven.org", tmpStr.substr(24), baseDir + PATH_SEPARATOR "normal.png");
-	textureStoreItems[id].normal = baseDir + PATH_SEPARATOR + "normal.png";
+	textureStoreItems[id].normal = baseDir + PATH_SEPARATOR "normal.png";
 	tmpStr = tmpJ["Rough"][std::to_string(res) + "k"]["png"]["url"];
 	DownloadFile("https://dl.polyhaven.org", tmpStr.substr(24), baseDir + PATH_SEPARATOR "roughness.png");
 	textureStoreItems[id].roughness = baseDir + PATH_SEPARATOR "roughness.png";

--- a/TerraForge3D/src/Utils/Utils.cpp
+++ b/TerraForge3D/src/Utils/Utils.cpp
@@ -35,6 +35,7 @@
 #include "GLFW/glfw3.h"
 #include "Application.h"
 #include "Data/ProjectData.h"
+#include "Platform.h"
 
 #ifndef TERR3D_WIN32
 #include <libgen.h>         // dirname

--- a/TerraForge3D/src/Utils/Utils.cpp
+++ b/TerraForge3D/src/Utils/Utils.cpp
@@ -35,7 +35,6 @@
 #include "GLFW/glfw3.h"
 #include "Application.h"
 #include "Data/ProjectData.h"
-#include "Platform.h"
 
 #ifndef TERR3D_WIN32
 #include <libgen.h>         // dirname


### PR DESCRIPTION
PR to the #31 
I've renamed `PATH_SEPERATOR` by `PATH_SEPARATOR` as it is the correct spelling. Then, I've replaced every `\\`, where it is not windows only, by `PATH_SEPARATOR` including `Platform.h` where it was missing.

Hope nothing breaks :sweat_smile: 